### PR TITLE
Remove client_endpoints from demo

### DIFF
--- a/config/powersync.yaml
+++ b/config/powersync.yaml
@@ -25,8 +25,6 @@
 telemetry:
   # Opt out of reporting anonymized usage metrics to PowerSync telemetry service
   disable_telemetry_sharing: false
-  # Additional Open Telemetry metrics endpoints
-  client_endpoints: []
 
 # Settings for source database replication
 replication:

--- a/schema/schema.json
+++ b/schema/schema.json
@@ -148,7 +148,7 @@
     },
     "telemetry": {
       "type": "object",
-      "properties": { "disable_telemetry_sharing": { "type": "boolean" }, "client_endpoints": { "type": "array", "items": { "type": "string" }  },
+      "properties": { "disable_telemetry_sharing": { "type": "boolean" } },
       "additionalProperties": true,
       "required": []
     }


### PR DESCRIPTION
The `client_endpoints` key is not currently used, so remove references to it.