### PR TITLE
docs: update env placeholders

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # PowerSync Self Hosted Example
 
+## v0.4.1
+
+- Cleaned `powersync.yaml` config file placeholder values
+
 ## v0.4.0
 
 - Added Supabase local development demo.

--- a/config/powersync.yaml
+++ b/config/powersync.yaml
@@ -60,7 +60,7 @@ replication:
       # This should be the certificate content in PEM format
       # client_certificate: !env PS_PG_CLIENT_CERT
       # This should be the key content in PEM format
-      # client_private_key: ${PS_PG_CLIENT_PRIVATE_KEY}
+      # client_private_key: !env PS_PG_CLIENT_PRIVATE_KEY
 
 # This is valid if using the `mongo` service defined in `ps-mongo.yaml`
 
@@ -91,10 +91,10 @@ client_auth:
   # jwks:
   #   keys:
   #     - kty: 'RSA'
-  #       n: '${PS_JWK_N}'
-  #       e: '${PS_JWK_E}'
+  #       n: !env PS_JWK_N
+  #       e: !env PS_JWK_E
   #       alg: 'RS256'
-  #       kid: '${PS_JWK_KID}'
+  #       kid: !env PS_JWK_KID
 
   # JWKS audience
   audience: ["powersync-dev", "powersync"]

--- a/config/powersync.yaml
+++ b/config/powersync.yaml
@@ -53,10 +53,13 @@ replication:
       # 'disable' is OK for local/private networks, not for public networks
 
       # Required for verify-ca, optional for verify-full
-      # cacert: ${PS_PG_CA_CERT}
+      # This should be the certificate(s) content in PEM format
+      # cacert: !env PS_PG_CA_CERT
 
       # Include a certificate here for HTTPs
-      # client_certificate: ${PS_PG_CLIENT_CERT}
+      # This should be the certificate content in PEM format
+      # client_certificate: !env PS_PG_CLIENT_CERT
+      # This should be the key content in PEM format
       # client_private_key: ${PS_PG_CLIENT_PRIVATE_KEY}
 
 # This is valid if using the `mongo` service defined in `ps-mongo.yaml`


### PR DESCRIPTION
# Overview

The comments in `powersync.yaml` contained some old syntax for placeholder values. These are now replaced with YAML `!env` placeholder functions. 

This is in response to [this](https://discord.com/channels/1138230179878154300/1280392963951955989) Discord community thread.