### PR TITLE
Use Next Image

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # PowerSync Self Hosted Example
 
+## v0.5.1
+
+- Use Next (development) PowerSync service image for testing.
+
 ## v0.5.0
 
 - Added alpha demo for MongoDB replication

--- a/README.md
+++ b/README.md
@@ -34,9 +34,11 @@ Edit the demo `.env` files and config files in the `./config` directory with you
 
 ### Connections
 
-Populate the `replication->connections` entry with your Postgres database connection details.
+Populate the `replication->connections` entry with your database connection details.
 
 A simple Postgres server is provided in the `ps-postgres.yaml` Docker compose file. Be sure to keep the credentials in `powersync.yaml` in sync with the config in `ps-postgres.yaml` if using this server.
+
+See the `nodejs-mongodb` demo for MongoDB connection configuration. 
 
 ### Storage
 

--- a/services/powersync.yaml
+++ b/services/powersync.yaml
@@ -1,7 +1,14 @@
 services:
   powersync:
     restart: unless-stopped
-    image: journeyapps/powersync-service:latest
+    # This currently uses a development image for the Next version of the PowerSync
+    # service. This Next version contains a new module system which will enable plugable
+    # functionality in the future. Functionality in this version should be the same as the
+    # latest stable version.
+    # Please report any issues experienced. Thank you for testing.
+    # Feel free to revert to the stable version by using
+    #   image: journeyapps/powersync-service:latest
+    image: journeyapps/powersync-service:0.0.0-dev-20240920084840
     # The unified service runs an API server and replication worker in the same container.
     # These services can be executed in different containers by using individual entry commands e.g.
     # Start only the API server with


### PR DESCRIPTION
# Overview

The PowerSync service will soon contain a modular architecture. This PR updates the self host demo to use a development Docker image based off this work. 

The latest work and image should be stable. The development image is used in these demos for smoke testing exposure. 