### PR TITLE
Add Memory Limit setting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # PowerSync Self Hosted Example
 
+## v0.5.2
+
+- Added note for PowerSync service memory limits using the `NODE_OPTIONS` environment variable.
+
 ## v0.5.1
 
 - Use Next (development) PowerSync service image for testing.

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ Populate the `replication->connections` entry with your database connection deta
 
 - **Postgres:** A simple Postgres server is provided in the `ps-postgres.yaml` Docker Compose file. Be sure to keep the credentials in `powersync.yaml` in sync with the config in `ps-postgres.yaml` if using this server.
 
-- **MongoDB:** See the [`nodejs-mongodb` demo](./demos/nodejs-mongodb/) for MongoDB connection configuration. 
+- **MongoDB:** See the [`nodejs-mongodb` demo](./demos/nodejs-mongodb/) for MongoDB connection configuration.
 
 ### Storage
 
@@ -55,6 +55,12 @@ The `key-generator` project demonstrates generating RSA key pairs for token sign
 ### Sync Rules
 
 [Sync Rules](https://docs.powersync.com/usage/sync-rules) are currently defined by placing them in `./config/sync_rules.yaml`.
+
+### Memory Limits
+
+It's recommended to set the `NODE_OPTIONS="--max-old-space-size=<size>"` environment variable to increase the default Node.js memory limit.
+
+Service memory limits should be adjusted to roughly 80 percent of the system memory capacity.
 
 # Cleanup
 

--- a/services/powersync.yaml
+++ b/services/powersync.yaml
@@ -42,6 +42,9 @@ services:
       #    command: ['start', '-r', 'unified', '-c64', '[base64 encoded content]']
       POWERSYNC_CONFIG_PATH: /config/powersync.yaml
 
+      # Service memory limits should be adjusted to roughly 80 percent of the system memory capacity
+      NODE_OPTIONS: --max-old-space-size=1000
+
       # Sync rules can be specified as base 64 encoded YAML
       # e.g: Via an environment variable
       # POWERSYNC_SYNC_RULES_B64: "[base64 encoded sync rules]"


### PR DESCRIPTION
# Overview

Syncing large datasets and/or having many concurrent client connections can increase the memory footprint of the PowerSync service. 

This PR adds a note for configuring the Node.js `max-old-space-size` setting for the PowerSync service.

Related: https://github.com/powersync-ja/powersync-service/issues/86