### PR TITLE
feat: use Supabase networks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # PowerSync Self Hosted Example
 
+## v0.6.0
+
+- Use Supabase Docker networks. This removes the use of `host.docker.internal` which is not always available on all Systems.
+
 ## v0.5.2
 
 - Added note for PowerSync service memory limits using the `NODE_OPTIONS` environment variable.

--- a/demos/supabase/.env.template
+++ b/demos/supabase/.env.template
@@ -3,10 +3,14 @@
 SUPABASE_URL=http://localhost:54321
 SUPABASE_ANON_KEY=
 
-# The Supabase Postgres connection is available on the host
-PG_DATABASE_HOSTNAME=host.docker.internal
+# The Supabase Postgres connection is available in the Supabase network
+# The Postgres container name is of the form `supabase_db_${project_id}`
+# Where `project_id` is configured in the config.toml file.
+PG_DATABASE_HOSTNAME=supabase_db_powersync_demo
 PG_DATABASE_NAME=postgres
-PG_DATABASE_PORT=5433 #This port has been configured in supabase/config.toml
+# This is the port in the Supabase network
+# The Postgres DB is exposed on a different port for the host
+PG_DATABASE_PORT=5432
 PG_DATABASE_USER=postgres
 PG_DATABASE_PASSWORD=postgres
 PS_DATA_SOURCE_URI=postgres://${PG_DATABASE_USER}:${PG_DATABASE_PASSWORD}@${PG_DATABASE_HOSTNAME}:${PG_DATABASE_PORT}/${PG_DATABASE_NAME}

--- a/demos/supabase/docker-compose.yaml
+++ b/demos/supabase/docker-compose.yaml
@@ -15,8 +15,9 @@ services:
         condition: service_completed_successfully
     volumes:
       - ./config:/config
-    environment:
-      PS_PG_URI: postgres://${PG_DATABASE_USER}:${PG_DATABASE_PASSWORD}@${PG_DATABASE_HOSTNAME}:${PG_DATABASE_PORT}/${PG_DATABASE_NAME}
+    networks:
+      - default
+      - supabase_network_powersync_demo
 
   demo-client:
     build:
@@ -27,3 +28,10 @@ services:
         VITE_POWERSYNC_URL: http://localhost:${PS_PORT}
     ports:
       - 4170:4173
+
+# Supabase exposes their services on this network
+networks:
+  # This is derived from `supabase_network_${project_id}`
+  # Where project_id is defined in the `config.toml` file.
+  supabase_network_powersync_demo:
+    external: true

--- a/demos/supabase/supabase/config.toml
+++ b/demos/supabase/supabase/config.toml
@@ -1,6 +1,6 @@
 # A string used to distinguish different Supabase projects on the same host. Defaults to the
 # working directory name when running `supabase init`.
-project_id = "project"
+project_id = "powersync_demo"
 
 [api]
 enabled = true
@@ -17,7 +17,7 @@ max_rows = 1000
 
 [db]
 # Port to use for the local database URL.
-port = 5433
+port = 54322
 # Port used by db diff command to initialize the shadow database.
 shadow_port = 54320
 # The database major version to use. This has to be the same as your remote database's. Run `SHOW


### PR DESCRIPTION
# Overview

The Supabase demo previously had the PowerSync Service connecting to the Supabase Postgres DB via `host.docker.internal`. `host.docker.internal` is not always available on certain systems e.g. some default Linux configurations. 

The PR updates the Docker configuration to connect to Supabase Postgres via the Supabase Docker network. 

Note that the Postgres port is 54322 on the host, but 5432 on the Supabase network.