### PR TITLE
feat: add healthcheck example

### DIFF
--- a/services/powersync.yaml
+++ b/services/powersync.yaml
@@ -75,6 +75,11 @@ services:
       # PS_JWK_N:
       # PS_JWK_E:
       # PS_JWK_KID:
-
+    # This requires image: journeyapps/powersync-service:0.5.8 or later
+    # healthcheck:
+    #   test: ["CMD", "node", "-e", "fetch('http://localhost:${PS_PORT}/probes/liveness').then(r => r.ok ? process.exit(0) : process.exit(1)).catch(() => process.exit(1))"]
+    #   interval: 5s
+    #   timeout: 1s
+    #   retries: 15
     ports:
       - ${PS_PORT}:${PS_PORT}


### PR DESCRIPTION
## Description
Add example of using Docker healthcheck in `powersync.yaml` with the new liveness endpoint

## Testing
I tested using the correct liveness URL and an incorrect URL where it started collecting failures 