### PR TITLE
feat: enable health checks

### DIFF
--- a/services/powersync.yaml
+++ b/services/powersync.yaml
@@ -69,10 +69,16 @@ services:
       # PS_JWK_E:
       # PS_JWK_KID:
     # This requires image: journeyapps/powersync-service:0.5.8 or later
-    # healthcheck:
-    #   test: ["CMD", "node", "-e", "fetch('http://localhost:${PS_PORT}/probes/liveness').then(r => r.ok ? process.exit(0) : process.exit(1)).catch(() => process.exit(1))"]
-    #   interval: 5s
-    #   timeout: 1s
-    #   retries: 15
+    healthcheck:
+      test:
+        [
+          "CMD",
+          "node",
+          "-e",
+          "fetch('http://localhost:${PS_PORT}/probes/liveness').then(r => r.ok ? process.exit(0) : process.exit(1)).catch(() => process.exit(1))"
+        ]
+      interval: 5s
+      timeout: 1s
+      retries: 15
     ports:
       - ${PS_PORT}:${PS_PORT}


### PR DESCRIPTION
# Overview

This enables the HTTP probe based health-checks example for PowerSync Docker services. 

A sample from executing `docker compose ps` shows that the health status is now reported in the Node.JS demo.

![image](https://github.com/user-attachments/assets/f96efbad-6671-4985-ab2e-6268815936f7)
