### PR TITLE
Postgres Bucket Storage Readme

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # PowerSync Self Hosted Example
 
+## 2025-02-03
+
+- Updated Postgres sync bucket storage readme.
+
 ## 2025-01-16
 
 - Updated PowerSync SDK packages in demo application.

--- a/demos/nodejs-postgres-bucket-storage/README.md
+++ b/demos/nodejs-postgres-bucket-storage/README.md
@@ -2,7 +2,7 @@
 
 This is a demo for using Postgres as the sync bucket storage driver with PowerSync.
 
-Separate Postgres servers are required for the bucket storage and replication data source.
+See the Postgres sync bucket storage [docs](https://docs.powersync.com/self-hosting/installation/powersync-service-setup#postgres-storage-beta) for more information.
 
 ## Running
 


### PR DESCRIPTION
# Overview

Postgres sync bucket storage now contain less limitations on the server configuration. This updates a small section of the readme to reflect the changes from https://github.com/powersync-ja/powersync-service/pull/186.

This still uses a separate server for the Postgres data source and sync bucket storage. This could be updated if required, I don't have any strong opinions on this. 

## TODOS

- [x] This requires a pending docs update