### PR TITLE
Include configurable logging options

### DIFF
--- a/config/powersync.yaml
+++ b/config/powersync.yaml
@@ -104,3 +104,11 @@ api:
   tokens:
     # These tokens are used for local admin API route authentication
     - use_a_better_token_in_production
+
+# System-level configuration options
+system:
+  # Service logging configuration
+  logging:
+    # Log level for the service logs
+    level: info #  'silly', 'debug', 'verbose', 'http', 'info', 'warn', 'error'
+    format: text # 'json' or 'text'

--- a/services/powersync.yaml
+++ b/services/powersync.yaml
@@ -55,6 +55,10 @@ services:
       # The port which the PowerSync API server should run on
       PS_PORT: ${PS_PORT}
 
+      # The order of precedence for logging config is: environment variables > config file > default (info/text)
+      # PS_LOG_LEVEL: info
+      # PS_LOG_FORMAT: text
+
       #  CA certificate for Postgres connection
       # PS_PG_CA_CERT:
 


### PR DESCRIPTION
Follow-up from https://github.com/powersync-ja/powersync-service/pull/477 and https://github.com/powersync-ja/powersync-service/pull/485

"Documents" the two ways to configure logging format and level (env vars and config keys) 

Tested various options with the stock postgres demo